### PR TITLE
Add firm-level clustering to production function estimation

### DIFF
--- a/g2. Production function and markup estimation.R
+++ b/g2. Production function and markup estimation.R
@@ -300,6 +300,7 @@ for(industry_temp in unique(reg_data$industry)){
     pf_model <- feols(
     as.formula(paste("ln_Y ~", paste(X_exog, collapse="+"), "| ", paste(fixed_effects, collapse="+"))),
     iv = as.formula(paste("~", paste(ENDOG, collapse="+"), " ~ ", paste(IVs, collapse="+"))),
+    cluster = ~firmid,
     data = d
   )
   }
@@ -308,7 +309,8 @@ for(industry_temp in unique(reg_data$industry)){
     pf_model <- felm(
     as.formula(paste(
       "ln_Y ~", paste(X_exog, collapse="+"),
-      "|", paste(fixed_effects, collapse="+") , "|", paste(ENDOG, collapse="+"), " ~ ", paste(IVs, collapse="+")
+      "|", paste(fixed_effects, collapse="+") , "|", paste(ENDOG, collapse="+"), " ~ ", paste(IVs, collapse="+"),
+      "| firmid"
     )),
     data = d
   )


### PR DESCRIPTION
## Summary
- Cluster standard errors by firm when estimating production functions
- Support firm-level clustering for optional felm estimator

## Testing
- `Rscript -e "0"` *(fails: command not found)*
- `Rscript "g2. Production function and markup estimation.R"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b6ddd34dcc8333ae6d08b1a69405e3